### PR TITLE
Fixes missing template exception when modules directory is not in root

### DIFF
--- a/modules/cbmessagebox/ModuleConfig.cfc
+++ b/modules/cbmessagebox/ModuleConfig.cfc
@@ -42,7 +42,7 @@ component {
 
 		//defaults
 		configStruct.messagebox = {
-			template 		= "#moduleMapping#/views/MessageBox.cfm",
+			template 		= "/#moduleMapping#/views/MessageBox.cfm",
 			styleOverride 	= false,
 			moduleRoot		= moduleMapping
 		};


### PR DESCRIPTION
Because the resolved module mapping is passed in to renderIt() without the leading slash, when the module directory is outside of the site root, a missing template exception is thrown.  Adding the leading slash fixes the include path.
