### PR TITLE
Delete the metadata added also on clearData=true

### DIFF
--- a/models/MessageBox.cfc
+++ b/models/MessageBox.cfc
@@ -332,7 +332,8 @@ component accessors="true" singleton{
 
 		// clear?
 		if( arguments.clearData ){
-			flash.remove( name=flashKey, saveNow=true );
+			flash.remove( name=variables.flashKey, saveNow=true );
+			flash.remove( name=variables.flashDataKey, saveNow=true );
 		}
 
 		return data;
@@ -369,7 +370,8 @@ component accessors="true" singleton{
 
 		// clear?
 		if( arguments.clearMessage ){
-			flash.remove( name=flashKey, saveNow=true );
+			flash.remove( name=variables.flashKey, saveNow=true );
+			flash.remove( name=variables.flashDataKey, saveNow=true );
 		}
 
 		return results;


### PR DESCRIPTION
Currently the data put in flash in the addData() method is not deleted when clearData is true in getData() also in clearMessage=true in renderIt()